### PR TITLE
Enable strict TypeScript mode

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -11,10 +11,20 @@ import {
   Users,
   Trophy,
   CheckCircle,
+  type LucideIcon,
 } from "lucide-react";
 import { useRef, useEffect, useState } from "react";
 
-const timeline = [
+interface TimelineItem {
+  year: string;
+  title: string;
+  desc: string;
+  icon: LucideIcon;
+  color: string;
+  badge: string;
+}
+
+const timeline: TimelineItem[] = [
   {
     year: "2020",
     title: "Início na programação",
@@ -57,7 +67,7 @@ const timeline = [
   },
 ];
 
-const valoresTimeline = [
+const valoresTimeline: TimelineItem[] = [
   {
     year: "Compromisso",
     title: "Excelência Técnica",
@@ -84,7 +94,7 @@ const valoresTimeline = [
   },
 ];
 
-const stackTimeline = [
+const stackTimeline: TimelineItem[] = [
   {
     year: "Frontend",
     title: "Stack Moderna",
@@ -113,7 +123,7 @@ const stackTimeline = [
 
 export default function About() {
   const [tab, setTab] = useState("stack");
-  const timelineRef = useRef(null);
+  const timelineRef = useRef<HTMLOListElement | null>(null);
 
   useEffect(() => {
     if (timelineRef.current) {
@@ -127,7 +137,7 @@ export default function About() {
     exit: { opacity: 0, y: -20 },
   };
 
-  const renderTimeline = (items) => (
+  const renderTimeline = (items: TimelineItem[]) => (
     <motion.ol
       ref={timelineRef}
       initial={{ opacity: 0 }}

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type FormEvent } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   Mail,
@@ -16,11 +16,11 @@ export default function Contact() {
   const [status, setStatus] = useState("idle");
   const [showConfetti, setShowConfetti] = useState(false);
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setStatus("sending");
 
-    const form = e.target;
+    const form = e.currentTarget;
     const data = new FormData(form);
 
     const res = await fetch("https://formspree.io/f/mkndwnen", {

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,10 +1,21 @@
 // Componente Projects com melhorias: filtro por tags, dark/light toggle, e navegação acessível
 import { useState, useEffect } from "react";
+
+interface Project {
+  title: string;
+  description: string;
+  tech: string[];
+  status: string;
+  category: string;
+  tags: string[];
+  link: string;
+  image: string;
+}
 import { motion } from "framer-motion";
 import Tilt from "react-parallax-tilt";
 import { LayoutGrid, ExternalLink, XCircle, Moon, Sun } from "lucide-react";
 
-const projects = [
+const projects: Project[] = [
   {
     title: "Painel SaaS Admin",
     description: "Dashboard com autenticação, gerenciamento e analytics.",
@@ -38,9 +49,9 @@ const projects = [
 ];
 
 export default function Projects() {
-  const [filter, setFilter] = useState("all");
-  const [tagFilter, setTagFilter] = useState(null);
-  const [selected, setSelected] = useState(null);
+  const [filter, setFilter] = useState<string>("all");
+  const [tagFilter, setTagFilter] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Project | null>(null);
   const [darkMode, setDarkMode] = useState(true);
 
   const filtered = projects.filter((p) => {
@@ -198,26 +209,26 @@ export default function Projects() {
           </div>
         )}
 
-        {selected && (
-          <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 px-4">
-            <div className="bg-zinc-900 border border-zinc-700 rounded-xl max-w-md w-full p-6 space-y-4 relative animate-in fade-in zoom-in-90">
-              <button
-                onClick={() => setSelected(null)}
-                className="absolute top-2 right-2 text-zinc-500 hover:text-red-500"
-              >
-                <XCircle className="w-5 h-5" />
-              </button>
-              <img
-                src={selected.image}
-                alt={selected.title}
-                className="rounded w-full h-32 object-cover"
-              />
-              <h3 className="text-lg font-bold text-blue-300">
-                {selected.title}
-              </h3>
-              <p className="text-zinc-300">{selected.description}</p>
-              <ul className="flex flex-wrap gap-2 text-sm">
-                {selected.tech.map((t, i) => (
+          {selected && (
+            <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 px-4">
+              <div className="bg-zinc-900 border border-zinc-700 rounded-xl max-w-md w-full p-6 space-y-4 relative animate-in fade-in zoom-in-90">
+                <button
+                  onClick={() => setSelected(null)}
+                  className="absolute top-2 right-2 text-zinc-500 hover:text-red-500"
+                >
+                  <XCircle className="w-5 h-5" />
+                </button>
+                <img
+                  src={selected!.image}
+                  alt={selected!.title}
+                  className="rounded w-full h-32 object-cover"
+                />
+                <h3 className="text-lg font-bold text-blue-300">
+                  {selected!.title}
+                </h3>
+                <p className="text-zinc-300">{selected!.description}</p>
+                <ul className="flex flex-wrap gap-2 text-sm">
+                  {selected!.tech.map((t, i) => (
                   <li
                     key={i}
                     className="bg-zinc-800 border border-zinc-600 px-2 py-0.5 rounded text-zinc-200"
@@ -226,8 +237,8 @@ export default function Projects() {
                   </li>
                 ))}
               </ul>
-              <a
-                href={selected.link}
+                <a
+                  href={selected!.link}
                 target="_blank"
                 className="inline-flex items-center gap-1 text-blue-400 hover:text-blue-300 text-sm"
               >

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     ],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "incremental": true,
     "module": "esnext",


### PR DESCRIPTION
## Summary
- enable `strict` mode in the TypeScript compiler
- add type annotations for project data and timeline items
- fix event and ref types in components

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_684851b88fcc832ca4a49d2c9d3403dd