### PR TITLE
Add Node build and log artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,24 @@
 node_modules
+# Next.js build output
+.next/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Test coverage
+coverage/
+.nyc_output/
+
+# Other Node.js artifacts
+build
+dist/
+
+# Environment files
+.env.local
+.env.*.local
+


### PR DESCRIPTION
## Summary
- expand `.gitignore` for a typical Node/Next.js project

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684851b52dc0832c8333aac0253687b2